### PR TITLE
Disallow specifying multiple log_type

### DIFF
--- a/man/xinetd.conf.5
+++ b/man/xinetd.conf.5
@@ -299,7 +299,7 @@ be accepted at the bounds of an interval). Hours can range from 0 to 23 and
 minutes from 0 to 59.
 .TP
 .B log_type
-determines where the service log output is sent. There are two formats:
+determines where the service log output is sent. Select just one of the two formats:
 .RS
 .TP
 .B SYSLOG " \fIsyslog_facility [syslog_level]\fP"

--- a/src/parsers.c
+++ b/src/parsers.c
@@ -934,6 +934,11 @@ status_e log_type_parser( pset_h values,
       missing_attr_msg(func, "log_type");
       return( FAILED );
    }
+
+   if ( LOG_GET_TYPE( lp ) != L_NONE) {
+      parsemsg( LOG_ERR, func, "Cannot set more than one log_type attribute");
+      return( FAILED );
+   }
    
    type = (char *) pset_pointer( values, 0 ) ;
 


### PR DESCRIPTION
xinetd doesn't support logging to multiple target so check it already in
parser to avoid unwanted consequences (this lead to double free upon
SIGHUP).