### PR TITLE
Fix single threaded tcp service with access control.

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -124,8 +124,9 @@ static status_e remote_address_check(const struct service *sp,
    bool_int   of_matched  = FALSE;
    bool_int   na_matched  = FALSE;
 
+   /* The IP address is unknown. Nothing to reject, so accept it. */
    if (sinp == NULL )
-      return FAILED;
+      return OK;
 
    if ( SC_SENSOR( SVC_CONF(sp) ))
    {   /* They hit a sensor...return FAILED since this isn't a real service */

--- a/src/child.c
+++ b/src/child.c
@@ -311,11 +311,6 @@ void child_process( struct server *serp )
    signals_pending[0] = -1;
    signals_pending[1] = -1;
 
-   Sclose(0);
-   Sclose(1);
-   Sclose(2);
-
-
 #ifdef DEBUG_SERVER
    if ( debug.on )
    {

--- a/src/connection.c
+++ b/src/connection.c
@@ -53,17 +53,16 @@ static status_e get_connection( struct service *sp, connection_s *cp )
       } else {
          cp->co_descriptor = accept( SVC_FD( sp ), &(cp->co_remote_address.sa),
                                      &sin_len ) ;
-	 if (cp->co_descriptor != -1)
-             M_SET( cp->co_flags, COF_NEW_DESCRIPTOR ) ;
-      }
-
-      if ( cp->co_descriptor == -1 )
-      {
-	 if ((errno == EMFILE) || (errno == ENFILE))
-	     cps_service_stop(sp, "no available descriptors");
-	 else
-             msg( LOG_ERR, func, "service %s, accept: %m", SVC_ID( sp ) ) ;
-         return( FAILED ) ;
+         if ( cp->co_descriptor == -1 )
+         {
+	    if ((errno == EMFILE) || (errno == ENFILE))
+	        cps_service_stop(sp, "no available descriptors");
+	    else
+                msg( LOG_ERR, func, "service %s, accept: %m", SVC_ID( sp ) ) ;
+            return( FAILED ) ;
+         }
+         M_SET( cp->co_flags, COF_NEW_DESCRIPTOR ) ;
+         M_SET( cp->co_flags, COF_HAVE_ADDRESS ) ;
       }
 
       if( SC_NODELAY( scp ) && (SC_PROTOVAL( scp ) == IPPROTO_TCP) )
@@ -88,8 +87,6 @@ static status_e get_connection( struct service *sp, connection_s *cp )
             if( debug.on ) msg( LOG_WARNING, func, "service %s, IPV6_ADDRFORM setsockopt() failed: %m", SVC_ID( sp) );
          }
       }
-
-      M_SET( cp->co_flags, COF_HAVE_ADDRESS ) ;
    }
    else
    {
@@ -210,7 +207,7 @@ const char *conn_addrstr( const connection_s *cp )
 
    if( getnameinfo( &cp->co_remote_address.sa, len,
          name, NI_MAXHOST, NULL, 0, NI_NUMERICHOST ) ) {
-      return "<no address>";
+      return "<invalid address>";
    }
    return name;
 }


### PR DESCRIPTION
Using only_from access control with a single threaded tcp service (protocol=tcp and wait=yes) doesn't work. I ran into the problem moving a service from Debian jessie (which doesn't set only_from) to Gentoo (where only_from=localhost is the default). The client is disconnected immediately and xinetd logs a burst of errors without ever starting the service.
```
Mar 26 22:23:20 localhost xinetd[15808]: xinetd Version 2.3.15 started with libwrap loadavg options compiled in.
Mar 26 22:23:20 localhost xinetd[15808]: Started working: 4 available services
Mar 26 22:24:16 localhost xinetd[15808]: START: myservice pid=16377 from=<no address>
Mar 26 22:24:16 localhost xinetd[16377]: FAIL: myservice address from=<no address>
Mar 26 22:24:16 localhost xinetd[15808]: EXIT: myservice status=0 pid=16377 duration=0(sec)
Mar 26 22:24:16 localhost xinetd[15808]: START: myservice pid=16378 from=<no address>
Mar 26 22:24:16 localhost xinetd[16378]: FAIL: myservice address from=<no address>
Mar 26 22:24:16 localhost xinetd[15808]: EXIT: myservice status=0 pid=16378 duration=0(sec)
...
Mar 26 22:24:16 localhost xinetd[15808]: START: myservice pid=16386 from=<no address>
Mar 26 22:24:16 localhost xinetd[16386]: FAIL: myservice address from=<no address>
Mar 26 22:24:16 localhost xinetd[15808]: EXIT: myservice status=0 pid=16386 duration=0(sec)
Mar 26 22:24:16 localhost xinetd[15808]: Deactivating service myservice due to excessive incoming connections.  Restarting in 10 seconds.
Mar 26 22:24:16 localhost xinetd[15808]: FAIL: myservice connections per second from=<no address>
Mar 26 22:24:26 localhost xinetd[15808]: Activating service myservice
```
The problem is that get_connection() sets the COF_HAVE_ADDRESS flag for all tcp connections, to indicate that the client address is known. But that's wrong for single-threaded tcp services where the connection is accept()'ed in the service daemon. Then remote_address_check() rejects the invalid client address. The fix is to not set the flag when it shouldn't be, and don't fail the access check when the client address is not yet known. (Also the "no address" error message above was generated in two places. Change one of them to make clear where the error is coming from.)

Fixing that exposed a bug with single-threaded services and INTERCEPT. It's a useful combination and the man page says it should work but it doesn't. The problem is that child_process() closes fds 0, 1, and 2 before forking the intercept process, the intercept code creates a socket to pass to the service daemon and gets fd 1, and then it calls child_process() again to spawn the daemon and fd 1 gets closed. There's no need to close those fds in child_process() because they're sanitized in setup_file_descriptors() when xinetd starts up and again in exec_server(). So don't do it. Then the socket fd is greater than 2 and doesn't get whacked.

Now my single-threaded tcp service works, with or without only_from access control, with or without INTERCEPT.
