### PR TITLE
No need to set IPV6_V6ONLY on client-side sockets

### DIFF
--- a/src/redirect.c
+++ b/src/redirect.c
@@ -95,19 +95,6 @@ void redir_handler( struct server *serp )
          exit(0);
       }
 
-      if( SC_IPV6( scp ) ) {
-         if( SC_V6ONLY( scp ) ) {
-            v6on = 1;
-         } else {
-            v6on = 0;
-         }
-#ifdef IPV6_V6ONLY
-         if( setsockopt(RedirServerFd, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&v6on, sizeof(v6on)) < 0 ) { 
-            msg( LOG_ERR, func, "Setting IPV6_V6ONLY option failed (%m)" );
-         }
-#endif
-
-      }
       if( SC_KEEPALIVE( scp ) )
          if (setsockopt(RedirServerFd, SOL_SOCKET, SO_KEEPALIVE, 
                         (char *)&on, sizeof( on ) ) < 0 )


### PR DESCRIPTION
Setting IPV6_V6ONLY on `RedirServerFd` (a client-side socket for connection to upstream server) makes no much sense. If upstream server is an IPv4 target, `setsockopt` fails and yields an error message.

For detail, see #11 .