### PR TITLE
Do not set server uid if effective user id is not super-user

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -270,16 +270,16 @@ static void set_credentials( const struct service_config *scp )
             }
          }
 #endif   /* ! NO_INITGROUPS */
-      }
-   }
 
-   if ( SC_SPECIFIED( scp, A_USER ) ) {
-         if ( setuid( SC_UID( scp ) ) == -1 )
-         {
-            msg( LOG_ERR, func, "setuid failed: %m" ) ;
-            _exit( 1 ) ;
+         if ( SC_SPECIFIED( scp, A_USER ) ) {
+            if ( setuid( SC_UID( scp ) ) == -1 )
+            {
+               msg( LOG_ERR, func, "setuid failed: %m" ) ;
+               _exit( 1 ) ;
+            }
          }
       }
+   }
 
    if ( SC_SPECIFIED( scp, A_UMASK ) ) 
       umask(SC_UMASK(scp));


### PR DESCRIPTION
The documentation to the user configuration property
specifies that it shall be ineffective if the effective
user id of xinetd is not super-user. Xinetd should
typically fail to change the user id of a server process
that it spawns if itself does not run as super-user.

Hence, this patch aligns the implementation with the
documented behavior and allows to run xinetd as
unprivileged user.

Fixes #19 