### PR TITLE
Add rate-limit option "leaky_bucket"

### DIFF
--- a/man/xinetd.conf.5
+++ b/man/xinetd.conf.5
@@ -508,6 +508,26 @@ seconds to wait before re\-enabling the service after it has been disabled.
 The default for this setting is 50 incoming connections and the interval
 is 10 seconds.
 .TP
+.B leaky_bucket
+Limits the rate of incoming connections over a custom interval of time using
+the leaky bucket algorithm.
+This option conflicts with the cps option.
+The leaky bucket algorithm works by logically having a a "bucket" with a
+count.
+The bucket fills at a constant rate (based on the connection rate) up to a
+maximum amount.
+For each connection attempt, the bucket count decrements by one.
+Once the bucket count goes below zero, the service is disabled temporarily.
+Takes four aguments.
+The first argument is the number of connections per interval.
+The second argument is the interval length in seconds.
+The third argument is the length of time to track the history in seconds (the
+length of time for the bucket to completely refill from empty).
+The fourth argument is the number of seconds to wait before re-enabling the
+service after it has been disabled.
+See https://en.wikipedia.org/wiki/Leaky_bucket for a description of the leaky
+bucket algorithm.
+.TP
 .B max_load
 Takes a floating point value as the load at which the service will
 stop accepting connections.  For example: 2 or 2.5.  The service

--- a/src/access.c
+++ b/src/access.c
@@ -281,8 +281,55 @@ access_e parent_access_control( struct service *sp, const connection_s *cp )
    if( (strncmp(SC_NAME( scp ), INTERCEPT_SERVICE_NAME, sizeof(INTERCEPT_SERVICE_NAME)) == 0) || (strncmp(SC_NAME( scp ), LOG_SERVICE_NAME, sizeof(LOG_SERVICE_NAME)) == 0) ) 
       return (AC_OK);
 
+   /* Leaky bucket rate-limit handler */
+   if( SC_SPECIFIED( scp, A_LEAKY_BUCKET ) && SC_TIME_CONN_MAX(scp) != 0 ) {
+      nowtime = time(NULL); // seconds
+      msg( LOG_DEBUG, __func__,
+            "Enforcing LB limit for service %s: nowtime = %lld",
+            SC_NAME( scp ), (long long) nowtime);
+
+      if( SC_LB_LAST_CONN_TIME(scp) == 0 ) {
+         /* first connection */
+         SC_LB_LAST_CONN_TIME(scp) = nowtime;
+         SC_LB_BUCKET_COUNT(scp) = SC_LB_INIT_BUCKET_COUNT(scp) - 1;
+         msg( LOG_DEBUG, __func__,
+               "    first LB connection: bucket_count = %f",
+               SC_LB_BUCKET_COUNT(scp));
+      } else {
+         time_t time_diff_secs;
+         time_diff_secs = nowtime - SC_LB_LAST_CONN_TIME(scp);
+         SC_LB_LAST_CONN_TIME(scp) = nowtime;
+         msg( LOG_DEBUG, __func__,
+               "    start_bucket_count = %f, diff_secs = %lld",
+               SC_LB_BUCKET_COUNT(scp), (long long) time_diff_secs );
+
+         /* Fill bucket based on elapsed time */
+         SC_LB_BUCKET_COUNT(scp) += time_diff_secs * SC_LB_FILL_PER_SEC(scp);
+
+         if (SC_LB_BUCKET_COUNT(scp) > SC_LB_INIT_BUCKET_COUNT(scp)) {
+            SC_LB_BUCKET_COUNT(scp) = SC_LB_INIT_BUCKET_COUNT(scp);
+         }
+
+         /* Decrement bucket for current connection */
+         SC_LB_BUCKET_COUNT(scp)--;
+
+         msg( LOG_DEBUG, __func__,
+               "    end_bucket_count = %f",
+               SC_LB_BUCKET_COUNT(scp));
+
+         if (SC_LB_BUCKET_COUNT(scp) < 0) {
+            SC_LB_BUCKET_COUNT(scp) = SC_LB_INIT_BUCKET_COUNT(scp);
+            cps_service_stop(sp, "excessive incoming connections");
+            return(AC_CPS);
+         }
+      }
+   }
+
    /* CPS handler */
-   if( SC_TIME_CONN_MAX(scp) != 0 ) {
+   /* Only run CPS logic when leaky_bucket is not being enforced because
+      even when 'cps' option is not specified, CPS is enforced by default. */
+   if( ! SC_SPECIFIED( scp, A_LEAKY_BUCKET ) && SC_TIME_CONN_MAX( scp ) != 0 ) {
+      msg( LOG_DEBUG, __func__, "CHECKING CPS");
       int time_diff;
       nowtime = time(NULL);
       time_diff = nowtime - SC_TIME_LIMIT(scp) ;
@@ -294,6 +341,7 @@ access_e parent_access_control( struct service *sp, const connection_s *cp )
          SC_TIME_CONN(scp)++;
          if( time_diff == 0 ) time_diff = 1;
          if( SC_TIME_CONN(scp)/time_diff > SC_TIME_CONN_MAX(scp) ) {
+            /* Stop the service; schedule the restart */
             cps_service_stop(sp, "excessive incoming connections");
             return(AC_CPS);
          }

--- a/src/attr.h
+++ b/src/attr.h
@@ -62,6 +62,7 @@
 #define A_MDNS             44
 #define A_LIBWRAP          45
 #define A_RLIMIT_FILES     46
+#define A_LEAKY_BUCKET     47
 
 /*
  * SERVICE_ATTRIBUTES is the number of service attributes and also

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -133,6 +133,13 @@ static status_e service_fill( struct service_config *scp,
        SC_SPECIFY(scp, A_SERVER);
    }
 
+   if (SC_SPECIFIED( scp, A_CPS ) && SC_SPECIFIED( scp, A_LEAKY_BUCKET )) {
+      msg(LOG_ERR, func,
+         "cps and leaky_bucket options are mutually exclusive: %s",
+         SC_NAME(scp));
+      return( FAILED ) ;
+   }
+
    if ( ! SC_IS_INTERNAL( scp ) && fix_server_argv( scp ) == FAILED )
       return( FAILED ) ;
 
@@ -168,7 +175,7 @@ static status_e service_fill( struct service_config *scp,
       SC_SPECIFY( scp, A_GROUPS );
    }
 
-   if ( ! SC_SPECIFIED( scp, A_CPS ) ) 
+   if ( ! SC_SPECIFIED( scp, A_CPS ) && ! SC_SPECIFIED( scp, A_LEAKY_BUCKET ) )
    {
       SC_TIME_CONN_MAX(scp) = SC_SPECIFIED( def, A_CPS ) ? 
          SC_TIME_CONN_MAX(def) : DEFAULT_LOOP_RATE;

--- a/src/parse.c
+++ b/src/parse.c
@@ -79,6 +79,7 @@ static const struct attribute service_attributes[] =
    { "banner_success", A_BANNER_SUCCESS, 1,  banner_success_parser  },
    { "banner_fail",    A_BANNER_FAIL,    1,  banner_fail_parser     },
    { "cps",            A_CPS,            2,  cps_parser             },
+   { "leaky_bucket",   A_LEAKY_BUCKET,   4,  leaky_bucket_parser    },
    { "disable",        A_SVCDISABLE,     1,  svcdisable_parser      },
 #ifdef HAVE_LOADAVG
    { "max_load",       A_MAX_LOAD,       1,  max_load_parser        },
@@ -128,6 +129,7 @@ static const struct attribute default_attributes[] =
    { "banner_success",  A_BANNER_SUCCESS,  1,   banner_success_parser },
    { "banner_fail",     A_BANNER_FAIL,     1,   banner_fail_parser    },
    { "cps",             A_CPS,             2,   cps_parser            },
+   { "leaky_bucket",    A_LEAKY_BUCKET,    4,   leaky_bucket_parser   },
    { "enabled",         A_ENABLED,        -2,   enabled_parser        },
 #ifdef HAVE_LOADAVG
    { "max_load",        A_MAX_LOAD,        1,   max_load_parser       },

--- a/src/parsers.c
+++ b/src/parsers.c
@@ -559,6 +559,75 @@ status_e cps_parser( pset_h values,
    return(OK);
 }
 
+status_e leaky_bucket_parser( pset_h values,
+                     struct service_config *scp,
+                     enum assign_op op )
+{
+   char *max_conn_per_interval = (char *) pset_pointer(values, 0);
+   char *interval_len_secs = (char *) pset_pointer(values, 1);
+   char *history_len_secs = (char *) pset_pointer(values, 2);
+   char *wait_time_secs = (char *) pset_pointer(values, 3);
+   unsigned int max_conn_per_interval_int, interval_len_secs_int, history_len_secs_int, wait_time_secs_int;
+
+   if( max_conn_per_interval == NULL || interval_len_secs == NULL || history_len_secs == NULL || wait_time_secs == NULL) {
+      parsemsg(LOG_ERR, __func__,
+         "NULL options specified in leaky_bucket; must specify: MAX_CONN_PER_INTERVAL INTERVAL_LEN_SECS HISTORY_LEN_SEC WAIT_TIME_SECS");
+      goto error;
+   }
+   if( parse_ubase10(max_conn_per_interval, &max_conn_per_interval_int) ) {
+      parsemsg(LOG_ERR, __func__,
+         "max_conn_per_interval argument not a number");
+      goto error;
+   }
+   if( parse_ubase10(interval_len_secs, &interval_len_secs_int) ) {
+      parsemsg(LOG_ERR, __func__,
+         "leaky_bucket interval_len_secs argument not a number");
+      goto error;
+   }
+   if( parse_ubase10(history_len_secs, &history_len_secs_int) ) {
+      parsemsg(LOG_ERR, __func__,
+         "leaky_bucket history_len_secs argument not a number");
+      goto error;
+   }
+   if( parse_ubase10(wait_time_secs, &wait_time_secs_int) ) {
+      parsemsg(LOG_ERR, __func__,
+         "leaky_bucket wait_time_secs argument not a number");
+      goto error;
+   }
+
+   if( max_conn_per_interval_int < 0
+      || interval_len_secs_int <= 0
+      || history_len_secs_int <= 0
+      || wait_time_secs_int <= 0) {
+      parsemsg(LOG_ERR, __func__, "leaky_bucket arguments invalid");
+      goto error;
+   }
+
+   SC_TIME_WAIT(scp) = wait_time_secs_int;
+   SC_TIME_CONN_MAX(scp) = max_conn_per_interval_int;
+   SC_LB_INTERVAL_LEN_SEC(scp) = interval_len_secs_int;
+   SC_LB_HISTORY_LEN_SEC(scp) = history_len_secs_int;
+
+   /* The fill rate should match the connection rate */
+   SC_LB_FILL_PER_SEC(scp) = (double) max_conn_per_interval_int / (double) interval_len_secs_int;
+
+   /* We want to "track" connection rate for history_len_secs_int, we take the
+    * fill per second rate times the history length in seconds.
+    */
+   SC_LB_INIT_BUCKET_COUNT(scp) = SC_LB_FILL_PER_SEC(scp) * (double) history_len_secs_int;
+
+   return(OK);
+
+   error:
+      SC_LB_INIT_BUCKET_COUNT(scp) = 0;
+      SC_LB_FILL_PER_SEC(scp) = 0.0;
+      SC_TIME_CONN_MAX(scp) = 0;
+      SC_TIME_WAIT(scp) = 0;
+      SC_LB_INTERVAL_LEN_SEC(scp) = 0;
+      SC_LB_HISTORY_LEN_SEC(scp) = 0;
+      return( FAILED );
+}
+
 status_e id_parser( pset_h values, 
                     struct service_config *scp, 
                     enum assign_op op )

--- a/src/parsers.h
+++ b/src/parsers.h
@@ -43,6 +43,7 @@ status_e groups_parser(pset_h, struct service_config *, enum assign_op) ;
 status_e banner_success_parser(pset_h, struct service_config *, enum assign_op) ;
 status_e banner_fail_parser(pset_h, struct service_config *, enum assign_op) ;
 status_e cps_parser(pset_h, struct service_config *, enum assign_op) ;
+status_e leaky_bucket_parser(pset_h, struct service_config *, enum assign_op) ;
 status_e enabled_parser(pset_h, struct service_config *, enum assign_op) ;
 status_e svcdisable_parser(pset_h, struct service_config *, enum assign_op);
 #ifdef HAVE_LOADAVG

--- a/src/sconf.c
+++ b/src/sconf.c
@@ -309,6 +309,18 @@ void sc_dump( struct service_config *scp,
       tabprint( fd, tab_level+1, "CPS = max conn:%lu wait:%lu\n", 
          SC_TIME_CONN_MAX(scp), SC_TIME_WAIT(scp) );
 
+   if ( SC_SPECIFIED( scp, A_LEAKY_BUCKET ) ) {
+      tabprint( fd, tab_level+1,
+         "LB = max conn %lld per %lld sec over %lld sec history, wait %lld sec\n",
+         (long long) SC_TIME_CONN_MAX(scp),
+         (long long) SC_LB_INTERVAL_LEN_SEC(scp),
+         (long long) SC_LB_HISTORY_LEN_SEC(scp),
+         (long long) SC_TIME_WAIT(scp) );
+      tabprint( fd, tab_level+1,
+         "     initial bucket count = %f, bucket fill per sec = %f\n",
+         SC_LB_INIT_BUCKET_COUNT(scp), SC_LB_FILL_PER_SEC(scp) );
+   }
+
    if ( SC_SPECIFIED( scp, A_PER_SOURCE ) )
       tabprint( fd, tab_level+1, "PER_SOURCE = %d\n", 
          SC_PER_SOURCE(scp) );

--- a/src/sconf.h
+++ b/src/sconf.h
@@ -138,6 +138,12 @@ struct service_config
    time_t               sc_time_conn_max ;
    time_t               sc_time_wait ;
    time_t               sc_time_reenable ;
+   time_t               sc_lb_last_conn_time ;
+   time_t               sc_lb_interval_len_sec ;
+   time_t               sc_lb_history_len_sec ;
+   double               sc_lb_bucket_count ;
+   double               sc_lb_init_bucket_count ;
+   double               sc_lb_fill_per_sec ;
    rlim_t               sc_rlim_as;
    rlim_t               sc_rlim_cpu;
    rlim_t               sc_rlim_data;
@@ -208,6 +214,12 @@ struct service_config
 #define SC_TIME_CONN_MAX( scp )  (scp)->sc_time_conn_max
 #define SC_TIME_WAIT( scp )      (scp)->sc_time_wait
 #define SC_TIME_REENABLE( scp )  (scp)->sc_time_reenable
+#define SC_LB_LAST_CONN_TIME( scp )     (scp)->sc_lb_last_conn_time
+#define SC_LB_INTERVAL_LEN_SEC( scp )   (scp)->sc_lb_interval_len_sec
+#define SC_LB_HISTORY_LEN_SEC( scp )    (scp)->sc_lb_history_len_sec
+#define SC_LB_BUCKET_COUNT( scp )       (scp)->sc_lb_bucket_count
+#define SC_LB_INIT_BUCKET_COUNT( scp )  (scp)->sc_lb_init_bucket_count
+#define SC_LB_FILL_PER_SEC( scp )       (scp)->sc_lb_fill_per_sec
 #define SC_UMASK( scp )          (scp)->sc_umask
 #define SC_DENY_TIME( scp )      (scp)->sc_deny_time
 #define SC_MDNS_NAME( scp )      (scp)->sc_mdns_name


### PR DESCRIPTION
Other inetd implementations (such as BSD) support rate-limit with
"connections per minute". However, xinetd only supports rate
limiting with the "cps" options, which uses "connections per second".

To be more flexible in the way rate-limit can be specified, this
adds the "leaky_bucket" option that allows the user to customize:

- Number of connections per interval
- Interval length (seconds)
- Length of history to track (seconds)
- Number of seconds to disable service if violated

Example use:

    leaky_bucket = 100 30 60 10

Translates to:

    Allow 100 connections per 30 sec over 60 sec history;
    wait 10 sec if limit is exceeded