### PR TITLE
Import missing patches from Fedora

### DIFF
--- a/man/xinetd.conf.5
+++ b/man/xinetd.conf.5
@@ -106,7 +106,8 @@ log option is not used.
 This will cause the first argument in "server_args" to be argv[0] when
 executing the server, as specified in "server".  This allows you to use
 tcpd by putting tcpd in "server" and the name of the server in "server_args"
-like in normal inetd.
+like in normal inetd. This flag has to be specified before "server_args",
+otherwise is not taken into account.
 .TP
 .B NODELAY
 If the service is a tcp service and the NODELAY flag is set, then the

--- a/src/access.c
+++ b/src/access.c
@@ -69,6 +69,7 @@ static void cps_service_restart(void)
    unsigned int i;
    time_t nowtime;
    const char *func = "cps_service_restart";
+   int rs;
 
    nowtime = time(NULL);
    for( i=0; i < pset_count( SERVICES(ps) ); i++ ) {
@@ -80,8 +81,11 @@ static void cps_service_restart(void)
       if( SVC_STATE(sp) == SVC_DISABLED ) {
          scp = SVC_CONF( sp );
          if ( SC_TIME_REENABLE(scp) <= nowtime ) {
+            rs = SVC_RUNNING_SERVERS(sp);
             /* re-enable the service */
             if( svc_activate(sp) == OK ) {
+               /* remember running servers after restart */
+               SVC_RUNNING_SERVERS(sp) = rs;
                msg(LOG_ERR, func,
                "Activating service %s", SC_NAME(scp));
             } else {

--- a/src/access.c
+++ b/src/access.c
@@ -89,9 +89,20 @@ static void cps_service_restart(void)
                msg(LOG_ERR, func,
                "Activating service %s", SC_NAME(scp));
             } else {
-               msg(LOG_ERR, func,
-               "Error activating service %s", 
-               SC_NAME(scp)) ;
+               /* Try to restart the service */
+               SVC_ATTEMPTS(sp) += 1;
+               if ( SVC_ATTEMPTS(sp) < MAX_SVC_ATTEMPTS ) {
+                  msg(LOG_ERR, func,
+                  "Error activating service %s, retrying %d more time(s)...",
+                  SC_NAME(scp),
+                  MAX_SVC_ATTEMPTS - SVC_ATTEMPTS(sp));
+                  xtimer_add(cps_service_restart, 1);
+               } else {
+                  /* Give up */
+                  msg(LOG_ERR, func,
+                  "Error activating service %s",
+                  SC_NAME(scp));
+               }
             } /* else */
          }
       }

--- a/src/child.c
+++ b/src/child.c
@@ -500,7 +500,7 @@ static int set_context_from_socket( const struct service_config *scp, int fd )
    if (getpeercon(fd, &peer_context) < 0)
      goto fail;
 
-   exepath = SC_SERVER_ARGV( scp )[0];
+   exepath = SC_SERVER( scp );
    if (getfilecon(exepath, &exec_context) < 0)
      goto fail;
 

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -100,14 +100,15 @@ void process_sensor( const struct service *sp, const union xsockaddr *addr)
 	 {
 	    /* Here again, eh?...update time stamp. */
             char *exp_time;
-	    time_t stored_time;
+	    int stored_time;
 
 	    item_matched--; /* Is # plus 1, to even get here must be >= 1 */
             exp_time = pset_pointer( global_no_access_time, item_matched ) ;
             if (exp_time == NULL)
                return ;
 
-            if ( parse_base10(exp_time, (int *)&stored_time) )
+            /* FIXME: Parse (long int) instead of (int) prior to possible Y2K38 bug. */
+            if ( parse_base10(exp_time, &stored_time ) )
             {  /* if never let them off, bypass */
                if (stored_time != -1)
                {

--- a/src/service.c
+++ b/src/service.c
@@ -156,6 +156,7 @@ static status_e activate_rpc( struct service *sp )
    socklen_t              sin_len = sizeof(tsin);
    unsigned long          vers ;
    struct service_config *scp = SVC_CONF( sp ) ;
+   uint16_t               service_port = SC_PORT( scp ) ;
    struct rpc_data       *rdp = SC_RPCDATA( scp ) ;
    char                  *sid = SC_ID( scp ) ;
    unsigned               registered_versions = 0 ;
@@ -172,9 +173,11 @@ static status_e activate_rpc( struct service *sp )
    }
    if( SC_IPV4( scp ) ) {
       tsin.sa_in.sin_family = AF_INET ;
+      tsin.sa_in.sin_port = htons( service_port ) ;
       sin_len = sizeof(struct sockaddr_in);
    } else if( SC_IPV6( scp ) ) {
       tsin.sa_in6.sin6_family = AF_INET6 ;
+      tsin.sa_in6.sin6_port = htons( service_port );
       sin_len = sizeof(struct sockaddr_in6);
    }
 

--- a/src/service.c
+++ b/src/service.c
@@ -189,6 +189,15 @@ static status_e activate_rpc( struct service *sp )
     */
    if ( getsockname( sd, &tsin.sa, &sin_len ) == -1 )
    {
+      if (SC_BIND_ADDR(scp) == NULL && SC_IPV6( scp ))
+      {
+         /* there was no bind address configured and IPv6 fails. Try IPv4 */
+         msg( LOG_NOTICE, func, "IPv6 socket creation failed for service %s, trying IPv4", SC_ID( scp ) ) ;
+         M_CLEAR(SC_XFLAGS(scp), SF_IPV6);
+         M_SET(SC_XFLAGS(scp), SF_IPV4);
+         return svc_activate(sp);
+      }
+
       msg( LOG_ERR, func,
             "getsockname failed (%m). service = %s", sid ) ;
       return( FAILED ) ;

--- a/src/service.c
+++ b/src/service.c
@@ -449,6 +449,7 @@ status_e svc_activate( struct service *sp )
     * Initialize the service data
     */
    SVC_RUNNING_SERVERS(sp)   = SVC_RETRIES(sp) = 0 ;
+   SVC_ATTEMPTS(sp) = 0;
 
    if ( SC_MUST_LISTEN( scp ) )
       (void) listen( SVC_FD(sp), LISTEN_BACKLOG ) ;

--- a/src/xconfig.h
+++ b/src/xconfig.h
@@ -59,6 +59,12 @@
 #define DEFAULT_LOOP_TIME			10
 
 /*
+ * The number of times to attempt re-activating a service after being
+ * deactivated due to the above.
+ */
+#define MAX_SVC_ATTEMPTS                         30
+
+/*
  * Signal-to-action mapping
  */
 #ifndef RECONFIG_HARD_SIG


### PR DESCRIPTION
Import missing patches from the (now retired) xinetd Fedora package at: https://src.fedoraproject.org/rpms/xinetd

Most of these applied as-is, or with minor adjustments. I've linked the original patch and bug report in every commit. Other patches in Fedora are either not relevant, or already applied. There is one patch left that I still need to go over (xinetd-2.3.14-poll.patch), but that is complex enough that it probably warrants a separate PR anyways, if it turns out to be still needed.