### PR TITLE
configure: Improve failures due to missing pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,9 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG([0.20])
+AS_IF([test -z "$PKG_CONFIG"],
+  [AC_MSG_WARN([pkg-config is needed for auto-configuration of dependencies])
+   PKG_CONFIG=false])
 AC_CHECK_LIB([m], [log10], [
     LIBM_LIBS="-lm"
 ], [


### PR DESCRIPTION
If pkg-config is missing or older than requested, the PKG_CONFIG variable
will be left empty, causing bogus error messages through the run of the
script.

Output a warning at the beginning, and fill PKG_CONFIG with "false" so
that any auto-configuration attempts fail without bogus messages.