### PR TITLE
xinetd segfaults when connecting to tcpmux service

### DIFF
--- a/man/xinetd.conf.5
+++ b/man/xinetd.conf.5
@@ -106,7 +106,8 @@ log option is not used.
 This will cause the first argument in "server_args" to be argv[0] when
 executing the server, as specified in "server".  This allows you to use
 tcpd by putting tcpd in "server" and the name of the server in "server_args"
-like in normal inetd.
+like in normal inetd. This flag has to be specified before "server_args",
+otherwise is not taken into account.
 .TP
 .B NODELAY
 If the service is a tcp service and the NODELAY flag is set, then the


### PR DESCRIPTION
Spun out of #25 as requested.

Original patch:
- https://src.fedoraproject.org/rpms/xinetd/c/d582efc71795ec2c2958c035f44da79fdae909b7?branch=rawhide
- https://src.fedoraproject.org/rpms/xinetd/c/07951ec3fca0568825b7c7fa2319be9e64bfee7a?branch=rawhide

Related:
- https://bugzilla.redhat.com/show_bug.cgi?id=1033528
- https://bugzilla.redhat.com/show_bug.cgi?id=1042652