### PR TITLE
Use full path to server when checking selinux context

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -500,7 +500,7 @@ static int set_context_from_socket( const struct service_config *scp, int fd )
    if (getpeercon(fd, &peer_context) < 0)
      goto fail;
 
-   exepath = SC_SERVER_ARGV( scp )[0];
+   exepath = SC_SERVER( scp );
    if (getfilecon(exepath, &exec_context) < 0)
      goto fail;
 


### PR DESCRIPTION
Spun out of #25 as requested.

Original patch: https://src.fedoraproject.org/rpms/xinetd/c/492bfbdc8649778cd39e823e662fd5fb3111aa9a?branch=rawhide
Related: https://bugzilla.redhat.com/show_bug.cgi?id=977873