### PR TITLE
Fix: Instances limit in xinetd can be easily bypassed

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -69,6 +69,7 @@ static void cps_service_restart(void)
    unsigned int i;
    time_t nowtime;
    const char *func = "cps_service_restart";
+   int rs;
 
    nowtime = time(NULL);
    for( i=0; i < pset_count( SERVICES(ps) ); i++ ) {
@@ -80,8 +81,11 @@ static void cps_service_restart(void)
       if( SVC_STATE(sp) == SVC_DISABLED ) {
          scp = SVC_CONF( sp );
          if ( SC_TIME_REENABLE(scp) <= nowtime ) {
+            rs = SVC_RUNNING_SERVERS(sp);
             /* re-enable the service */
             if( svc_activate(sp) == OK ) {
+               /* remember running servers after restart */
+               SVC_RUNNING_SERVERS(sp) = rs;
                msg(LOG_ERR, func,
                "Activating service %s", SC_NAME(scp));
             } else {


### PR DESCRIPTION
Spun out of #25 as requested.

Original patch: https://src.fedoraproject.org/rpms/xinetd/c/5ae7170961e48c7ef7d3ea8b503b3348ba8a7057?branch=rawhide
Related: https://bugzilla.redhat.com/show_bug.cgi?id=770858