### PR TITLE
Let RPC services bind to a port

### DIFF
--- a/man/xinetd.conf.5
+++ b/man/xinetd.conf.5
@@ -639,7 +639,7 @@ The necessary attributes for a service are:
 (\fIunlisted\fP RPC services only)
 .TP
 .B port
-(\fIunlisted\fP non\-RPC services only)
+(\fIRPC\fP and \fIunlisted\fP services only)
 .RE
 .PD
 .LP

--- a/src/service.c
+++ b/src/service.c
@@ -156,7 +156,7 @@ static status_e activate_rpc( struct service *sp )
    socklen_t              sin_len = sizeof(tsin);
    unsigned long          vers ;
    struct service_config *scp = SVC_CONF( sp ) ;
-   uint16_t               service_port = SC_PORT( scp ) ;
+   uint16_t               service_port = SC_SPECIFIED( scp, A_PORT ) ? SC_PORT ( scp ) : 0 ;
    struct rpc_data       *rdp = SC_RPCDATA( scp ) ;
    char                  *sid = SC_ID( scp ) ;
    unsigned               registered_versions = 0 ;
@@ -245,7 +245,7 @@ static status_e activate_normal( struct service *sp )
    union xsockaddr         tsin;
    int                     sd             = SVC_FD( sp ) ;
    struct service_config  *scp            = SVC_CONF( sp ) ;
-   uint16_t                service_port   = SC_PORT( scp ) ;
+   uint16_t                service_port   = SC_SPECIFIED( scp, A_PORT ) ? SC_PORT( scp ) : 0 ;
    char                   *sid            = SC_ID( scp ) ;
    const char             *func           = "activate_normal" ;
    unsigned int            sin_len        = sizeof(tsin);

--- a/src/service.c
+++ b/src/service.c
@@ -156,6 +156,7 @@ static status_e activate_rpc( struct service *sp )
    socklen_t              sin_len = sizeof(tsin);
    unsigned long          vers ;
    struct service_config *scp = SVC_CONF( sp ) ;
+   uint16_t               service_port = SC_PORT( scp ) ;
    struct rpc_data       *rdp = SC_RPCDATA( scp ) ;
    char                  *sid = SC_ID( scp ) ;
    unsigned               registered_versions = 0 ;
@@ -172,9 +173,11 @@ static status_e activate_rpc( struct service *sp )
    }
    if( SC_IPV4( scp ) ) {
       tsin.sa_in.sin_family = AF_INET ;
+      tsin.sa_in.sin_port = htons( service_port ) ;
       sin_len = sizeof(struct sockaddr_in);
    } else if( SC_IPV6( scp ) ) {
       tsin.sa_in6.sin6_family = AF_INET6 ;
+      tsin.sa_in6.sin6_port = htons( service_port );
       sin_len = sizeof(struct sockaddr_in6);
    }
 


### PR DESCRIPTION
Spun out of #25 as requested.

Original patch: https://src.fedoraproject.org/rpms/xinetd/c/f48798436d1961de0228e92a02c1fc82ce9260f5?branch=rawhide
Related: https://bugzilla.redhat.com/show_bug.cgi?id=624800