### PR TITLE
Fallback on IPv4 on error when binding

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -189,6 +189,15 @@ static status_e activate_rpc( struct service *sp )
     */
    if ( getsockname( sd, &tsin.sa, &sin_len ) == -1 )
    {
+      if (SC_BIND_ADDR(scp) == NULL && SC_IPV6( scp ))
+      {
+         /* there was no bind address configured and IPv6 fails. Try IPv4 */
+         msg( LOG_NOTICE, func, "IPv6 socket creation failed for service %s, trying IPv4", SC_ID( scp ) ) ;
+         M_CLEAR(SC_XFLAGS(scp), SF_IPV6);
+         M_SET(SC_XFLAGS(scp), SF_IPV4);
+         return svc_activate(sp);
+      }
+
       msg( LOG_ERR, func,
             "getsockname failed (%m). service = %s", sid ) ;
       return( FAILED ) ;

--- a/src/service.c
+++ b/src/service.c
@@ -189,13 +189,13 @@ static status_e activate_rpc( struct service *sp )
     */
    if ( getsockname( sd, &tsin.sa, &sin_len ) == -1 )
    {
-      if (SC_BIND_ADDR(scp) == NULL && SC_IPV6( scp ))
+      if ( SC_BIND_ADDR(scp) == NULL && SC_IPV6( scp ) )
       {
          /* there was no bind address configured and IPv6 fails. Try IPv4 */
          msg( LOG_NOTICE, func, "IPv6 socket creation failed for service %s, trying IPv4", SC_ID( scp ) ) ;
-         M_CLEAR(SC_XFLAGS(scp), SF_IPV6);
-         M_SET(SC_XFLAGS(scp), SF_IPV4);
-         return svc_activate(sp);
+         M_CLEAR( SC_XFLAGS( scp ), SF_IPV6 );
+         M_SET( SC_XFLAGS( scp ), SF_IPV4 );
+         return svc_activate( sp );
       }
 
       msg( LOG_ERR, func,


### PR DESCRIPTION
Spun out of #25 as requested.

We already bind the socket to IPv6 by default; if no bind address is
configured and IPv6 fails, fallback to IPv4.

Original patch: https://src.fedoraproject.org/rpms/xinetd/c/ac3545dde2e78604fd44a559502c9af3c890db2b?branch=rawhide
Related: https://bugzilla.redhat.com/show_bug.cgi?id=195265