### PR TITLE
use monotonic time

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -71,7 +71,7 @@ static void cps_service_restart(void)
    const char *func = "cps_service_restart";
    int rs;
 
-   nowtime = time(NULL);
+   nowtime = _time(NULL);
    for( i=0; i < pset_count( SERVICES(ps) ); i++ ) {
       struct service *sp;
       struct service_config *scp;
@@ -119,7 +119,7 @@ void cps_service_stop(struct service *sp, const char *reason)
    msg(LOG_ERR, "service_stop", 
 	"Deactivating service %s due to %s.  Restarting in %d seconds.", 
 	SC_NAME(scp), reason, (int)SC_TIME_WAIT(scp));
-   nowtime = time(NULL);
+   nowtime = _time(NULL);
    SC_TIME_REENABLE(scp) = nowtime + SC_TIME_WAIT(scp);
    xtimer_add(cps_service_restart, SC_TIME_WAIT(scp));
 }
@@ -299,7 +299,7 @@ access_e parent_access_control( struct service *sp, const connection_s *cp )
    /* CPS handler */
    if( SC_TIME_CONN_MAX(scp) != 0 ) {
       int time_diff;
-      nowtime = time(NULL);
+      nowtime = _time(NULL);
       time_diff = nowtime - SC_TIME_LIMIT(scp) ;
 
       if( SC_TIME_CONN(scp) == 0 ) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -36,6 +36,7 @@
 #include "nvlists.h"
 #include "child.h"
 #include "access.h"
+#include "xtimer.h"
 
 #define BUFFER_SIZE               1024
 
@@ -237,7 +238,7 @@ static void daytime_protocol( char *buf, unsigned int *buflen )
    int         size = *buflen ;
    int      cc ;
 
-   (void) time( &now ) ;
+   (void) _time( &now ) ;
    tmp = localtime( &now ) ;
    cc = strx_nprint( buf, size,
       "%02d %s %d %02d:%02d:%02d",
@@ -308,7 +309,7 @@ static void time_protocol( unsigned char *timep )
    time_t now ;
    unsigned long base1900;
 
-   (void) time( &now ) ;
+   (void) _time( &now ) ;
    base1900 = (unsigned long)now + TIME_OFFSET ;
    timep[0] = base1900 >> 24;
    timep[1] = base1900 >> 16;

--- a/src/internals.c
+++ b/src/internals.c
@@ -85,7 +85,7 @@ void dump_internal_state(void)
     * Print the program name, version, and timestamp.
     * Note that the program_version variable contains the program name.
     */
-   (void) time( &current_time ) ;
+   (void) _time( &current_time ) ;
    Sprint( dump_fd, "INTERNAL STATE DUMP: %s\n", program_version ) ;
    Sprint( dump_fd, "Current time: %s\n", ctime( &current_time ) ) ;
 

--- a/src/log.c
+++ b/src/log.c
@@ -21,6 +21,7 @@
 #include "sconf.h"
 #include "sconst.h"
 #include "msg.h"
+#include "xtimer.h"
 
 
 #define LOGBUF_SIZE                  1024
@@ -202,7 +203,7 @@ void svc_log_exit( struct service *sp, const struct server *serp )
    {
       time_t current_time ;
 
-      (void) time( &current_time ) ;
+      (void) _time( &current_time ) ;
       cc = strx_nprint( &buf[ len ], bufsize, " duration=%ld(sec)",
          (long)(current_time - SERVER_STARTTIME( serp )) ) ;
       len += cc ;

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -68,7 +68,7 @@ void process_sensor( const struct service *sp, const union xsockaddr *addr)
                time_t nowtime;
                char time_buf[40], *tmp;
 
-	       nowtime = time(NULL);
+	       nowtime = _time(NULL);
 	       msg(LOG_CRIT, func,
 	           "Adding %s to the global_no_access list for %d minutes",
 	            dup_addr, SC_DENY_TIME(SVC_CONF(sp)));
@@ -113,7 +113,7 @@ void process_sensor( const struct service *sp, const union xsockaddr *addr)
                {
                   time_t nowtime, new_time;
 
-                  nowtime = time(NULL);
+                  nowtime = _time(NULL);
                   new_time = (time_t)nowtime+(60*SC_DENY_TIME(SVC_CONF(sp)));                     if (difftime(new_time, (time_t)stored_time) > 0.0)
 	          {   /* new_time is longer save it   */
 		     char time_buf[40], *new_exp_time;
@@ -163,7 +163,7 @@ static void scrub_global_access_list( void )
    {
       int found_one = 0;
       unsigned u;
-      time_t nowtime = time(NULL);
+      time_t nowtime = _time(NULL);
 
       for (u=0; u < count; u++)
       {

--- a/src/server.c
+++ b/src/server.c
@@ -30,6 +30,7 @@
 #include "retry.h"
 #include "child.h"
 #include "signals.h"
+#include "xtimer.h"
 
 
 #define NEW_SERVER()                NEW( struct server )
@@ -228,7 +229,7 @@ status_e server_start( struct server *serp )
          return( FAILED ) ;
 
       default:
-         (void) time( &SERVER_STARTTIME(serp) ) ;
+         (void) _time( &SERVER_STARTTIME(serp) ) ;
          SVC_INC_RUNNING_SERVERS( sp ) ;
 
          /*

--- a/src/service.c
+++ b/src/service.c
@@ -43,6 +43,7 @@
 #include "logctl.h"
 #include "xconfig.h"
 #include "special.h"
+#include "xtimer.h"
 
 
 #define NEW_SVC()              NEW( struct service )
@@ -853,7 +854,7 @@ static status_e failed_service(struct service *sp,
 	       SVC_LAST_DGRAM_ADDR(sp) = (union xsockaddr *)last;
             }
 
-            (void) time( &current_time ) ;
+            (void) _time( &current_time ) ;
             if ( sinp->sin_addr.s_addr == last->sin_addr.s_addr &&
                                           sinp->sin_port == last->sin_port )
             {
@@ -880,7 +881,7 @@ static status_e failed_service(struct service *sp,
 	       SVC_LAST_DGRAM_ADDR( sp ) = (union xsockaddr *)last;
             }
 
-            (void) time( &current_time ) ;
+            (void) _time( &current_time ) ;
             if ( IN6_ARE_ADDR_EQUAL(&(sinp->sin6_addr), &(last->sin6_addr)) && 
                  sinp->sin6_port == last->sin6_port )
             {

--- a/src/signals.c
+++ b/src/signals.c
@@ -301,7 +301,7 @@ static void bad_signal(void)
    else if ( total_signal_count > MAX_SIGNAL_COUNT )
       _exit( 1 ) ;      /* in case of a problem in exit(3) */
    
-   (void) time( &current_time ) ;
+   (void) _time( &current_time ) ;
 
    if ( interval_signal_count > 0 &&
             current_time - interval_start <= SIGNAL_INTERVAL )

--- a/src/time.c
+++ b/src/time.c
@@ -16,6 +16,7 @@
 #include "timex.h"
 #include "msg.h"
 #include "util.h"
+#include "xtimer.h"
 
 
 #define IN_RANGE( val, low, high )     ( (low) <= (val) && (val) <= (high) )
@@ -41,7 +42,7 @@ bool_int ti_current_time_check( const pset_h intervals )
    int16_t     min_current ;
    struct tm   *tmp ;
 
-   (void) time( &current_time ) ;
+   (void) _time( &current_time ) ;
    tmp = localtime( &current_time ) ;
    min_current = tmp->tm_hour * 60 + tmp->tm_min ;
 

--- a/src/xlog/filelog.c
+++ b/src/xlog/filelog.c
@@ -25,6 +25,7 @@
 #include "str.h"
 #include "xlog.h"
 #include "filelog.h"
+#include "xtimer.h"
 
 static int filelog_init(xlog_s *, va_list) ;
 static void filelog_fini(xlog_s *) ;
@@ -190,7 +191,7 @@ static int filelog_write( xlog_s *xp, const char buf[], int len, int flags,
 	if ( flp->fl_state != FL_OPEN )
 		return( flp->fl_error ) ;
 
-	(void) time( &current_time ) ;
+	(void) _time( &current_time ) ;
 	tmp = localtime( &current_time ) ;
 	cc = Sprint( flp->fl_fd, "%02d/%d/%d@%02d:%02d:%02d",
 		tmp->tm_year%100, tmp->tm_mon+1, tmp->tm_mday,

--- a/src/xtimer.c
+++ b/src/xtimer.c
@@ -11,6 +11,15 @@
 #include "pset.h"
 #include "msg.h"
 
+time_t _time(time_t *t)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	if(t)
+		*t = ts.tv_sec;
+	return ts.tv_sec;
+}
+
 /* A note on the usage of timers in these functions:
  * The timers are composed of 3 elements, a pointer to a callback function,
  * the expire time of the timer, and a unique (pseudo-monotomically increasing)
@@ -68,7 +77,7 @@ int xtimer_add( void (*func)(void), time_t secs )
 		return -1;
 	}
 
-	tmptime = time(NULL);
+	tmptime = _time(NULL);
 	if( tmptime == -1 ) {
 		free( new_xtimer );
 		return -1;
@@ -107,7 +116,7 @@ int xtimer_poll(void)
 
 	for( i = 0; i < pset_count( xtimer_list ); i++ ) {
 		xtime_h *cur_timer = pset_pointer( xtimer_list, i );
-		time_t cur_time    = time(NULL);
+		time_t cur_time    = _time(NULL);
 
 		/* The list is sorted, low to high.  If there's no
 		 * timers left, return.
@@ -163,7 +172,7 @@ time_t xtimer_nexttime(void)
 	if( pset_count(xtimer_list) == 0 )
 		return -1;
 
-	ret = ((xtime_h *)pset_pointer(xtimer_list, 0))->when - time(NULL) ;
+	ret = ((xtime_h *)pset_pointer(xtimer_list, 0))->when - _time(NULL) ;
 	if( ret < 0 )
 		ret = 0;
 	return( ret );

--- a/src/xtimer.h
+++ b/src/xtimer.h
@@ -22,4 +22,5 @@ int xtimer_poll(void);
 int xtimer_remove(int);
 time_t xtimer_nexttime(void);
 
+time_t _time(time_t *t);
 #endif /* _X_TIMER_H */


### PR DESCRIPTION
when using xinet.d to limit rsync connections and time is set back, the connection limit is reached very quickly and rsync gets deactivated, if time is changed again, rsync is never reactivated.

date -s "xxx"
xinetd[xxx]: Deactivating service rsync due to excessive incoming connections. Restarting in 10 seconds.

the timer of xinet.d is based on time() function, and it is affected by system time.